### PR TITLE
Adjust background of linear picker views

### DIFF
--- a/CircleColorPicker/ColorPicker/Views/CircleColorPickerView/CircleColorPickerView.swift
+++ b/CircleColorPicker/ColorPicker/Views/CircleColorPickerView/CircleColorPickerView.swift
@@ -214,10 +214,10 @@ open class CircleColorPickerView: UIView {
         }
         
         colorBubbleView.setBubbleColor(color: colorWithOnlyHue)
-        saturationPickerView?.backgroundColor = colorWithOnlyHue
-        brightnessPickerView?.backgroundColor = colorWithOnlyHue
-        saturationPickerView?.bubbleView.backgroundColor = colorWithSaturation
-        brightnessPickerView?.bubbleView.backgroundColor = colorWithBrightness
+        saturationPickerView?.backgroundColor = colorWithBrightness
+        brightnessPickerView?.backgroundColor = colorWithSaturation
+        saturationPickerView?.bubbleView.backgroundColor = color
+        brightnessPickerView?.bubbleView.backgroundColor = color
     }
     
     private func setBubbleAngleForCurrentHue(){

--- a/CircleColorPicker/ColorPicker/Views/LinearPickers/BrightnessPickerView.swift
+++ b/CircleColorPicker/ColorPicker/Views/LinearPickers/BrightnessPickerView.swift
@@ -11,22 +11,30 @@ import UIKit
 open class BrightnessPickerView: LinearPickerView {
 
     open override func handleOrientationChange() {
-        (frontLayerView as! BrightnessMask).isVertical = isVertical
+        (frontLayerView as! BrightnessGradient).isVertical = isVertical
     }
     
     open override func createFrontLayerView() -> UIView{
-        let frontLayer = BrightnessMask(frame: CGRect.init(origin: CGPoint.zero, size: self.bounds.size))
+        let frontLayer = BrightnessGradient(frame: CGRect.init(origin: CGPoint.zero, size: self.bounds.size))
         frontLayer.isVertical = isVertical
         return frontLayer
     }
+
+    open override func updateFrontLayerView() {
+        let brightnessGradient = self.frontLayerView as? BrightnessGradient
+        brightnessGradient?.backgroundColor = self.backgroundColor
+        brightnessGradient?.setNeedsLayout()
+    }
     
-    class BrightnessMask: UIView {
+    class BrightnessGradient: UIView {
         public var isVertical = false
         
         func drawScale(context: CGContext){
+            var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+            self.backgroundColor?.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
             
-            let startColor = UIColor.init(hue: 1, saturation: 0, brightness: 0, alpha: 1).cgColor
-            let endColor   = UIColor.init(hue: 1, saturation: 0, brightness: 0, alpha: 0).cgColor
+            let startColor = UIColor.init(hue: h, saturation: s, brightness: 0, alpha: 1).cgColor
+            let endColor   = UIColor.init(hue: h, saturation: s, brightness: 1, alpha: 1).cgColor
             
             let colorSpace = CGColorSpaceCreateDeviceRGB()
             let colors = [startColor, endColor] as CFArray

--- a/CircleColorPicker/ColorPicker/Views/LinearPickers/LinearPickerView.swift
+++ b/CircleColorPicker/ColorPicker/Views/LinearPickers/LinearPickerView.swift
@@ -41,6 +41,12 @@ open class LinearPickerView: UIView {
         }
         
     }
+
+    open override var backgroundColor: UIColor? {
+        didSet {
+            self.updateFrontLayerView()
+        }
+    }
     
     @IBOutlet var contentView: UIView!
     @IBOutlet open weak var bubbleView: UIImageView!
@@ -96,6 +102,10 @@ open class LinearPickerView: UIView {
         
         contentView!.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         addSubview(contentView!)
+    }
+
+    open func updateFrontLayerView() {
+        print("Subclasses of LinearPickerView should override updateFrontLayerView() function.")
     }
     
     open func handleOrientationChange() {

--- a/CircleColorPicker/ColorPicker/Views/LinearPickers/SaturationPickerView.swift
+++ b/CircleColorPicker/ColorPicker/Views/LinearPickers/SaturationPickerView.swift
@@ -11,22 +11,30 @@ import UIKit
 open class SaturationPickerView: LinearPickerView {
 
     open override func handleOrientationChange() {
-        (frontLayerView as! SaturationMask).isVertical = isVertical
+        (frontLayerView as! SaturationGradient).isVertical = isVertical
     }
     
     open override func createFrontLayerView() -> UIView{
-        let frontLayer = SaturationMask(frame: CGRect.init(origin: CGPoint.zero, size: self.bounds.size))
+        let frontLayer = SaturationGradient(frame: CGRect.init(origin: CGPoint.zero, size: self.bounds.size))
         frontLayer.isVertical = isVertical
         return frontLayer
     }
+
+    open override func updateFrontLayerView() {
+        let saturationGradient = self.frontLayerView as? SaturationGradient
+        saturationGradient?.backgroundColor = self.backgroundColor
+        saturationGradient?.setNeedsLayout()
+    }
     
-    class SaturationMask: UIView {
+    class SaturationGradient: UIView {
         public var isVertical = false
         
         func drawScale(context: CGContext){
+            var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+            self.backgroundColor?.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
             
-            let startColor = UIColor.init(hue: 1, saturation: 0, brightness: 1, alpha: 1).cgColor
-            let endColor   = UIColor.init(hue: 1, saturation: 0, brightness: 1, alpha: 0).cgColor
+            let startColor = UIColor.init(hue: h, saturation: 0, brightness: b, alpha: 1).cgColor
+            let endColor   = UIColor.init(hue: h, saturation: 1, brightness: b, alpha: 1).cgColor
             
             let colorSpace = CGColorSpaceCreateDeviceRGB()
             let colors = [startColor, endColor] as CFArray


### PR DESCRIPTION
Problem:
The backgrounds of the brightness and saturation picker views should show the correct colors if the other slider has been moved

Analysis:
The linear picker views have a mask that are used as overlay to display the gradient and the background colors are set to display the hue value only

Solution:
Instead of using a layer mask, the frontLayer is now not transparent anymore but is using the current background color as gradient endpoint. Whenever the background color changes this gradient is recalculated to match the selected colors. In the CircleColorPickerView, the background colors are now set to match the opposite (saturation -> fixed brightness, brightness ->  fixed saturation). The bubble views use the current color so get a nice finish.